### PR TITLE
Fixed TL;DR

### DIFF
--- a/practical-guide-to-ntlm-relaying-in-2017-aka-getting-a-foothold-in-under-5-minutes.html
+++ b/practical-guide-to-ntlm-relaying-in-2017-aka-getting-a-foothold-in-under-5-minutes.html
@@ -55,7 +55,7 @@
 <p>Before we dive into the thick of it we need make sure we are on the same page with a couple of things.</p>
 <h1>NTLM vs. NTLMv1/v2 vs. Net-NTLMv1/v2</h1>
 <p>This is where the confusion starts for a lot of people and quite frankly I don't blame them because all of the articles about this attack talk about NTLMv1/v2, so when they see Net-NTLMv1/v2 anywhere obviously people wonder if it's the same thing.</p>
-<p><strong>TL;DR NTLMv1/v2 and Net-NTLMv1/v2 are the same thing</strong></p>
+<p><strong>TL;DR NTLMv1/v2 and Net-NTLMv1/v2 are NOT the same thing</strong></p>
 <p>However, NTLM and Net-NTLM are very different types of hashes.</p>
 <p>NTLM hashes are stored in the Security Account Manager (SAM) database and in Domain Controller's NTDS.dit database. They look like this:</p>
 <div class="highlight"><pre><span></span><span class="n">aad3b435b51404eeaad3b435b51404ee</span><span class="o">:</span><span class="n">e19ccf75ee54e06b06a5907af13cef42</span>


### PR DESCRIPTION
Thanks for the write-up.

Based on your article, the tl;dr should say NTLMv1/v2 and Net-NTLMv1/v2 are NOT the same thing. 
This is why not (quotes taken from the article):

- "However,  NTLM and Net-NTLM are very different types of hashes."

- "From  a pentesting perspective:

     You CAN perform Pass-The-Hash attacks with NTLM hashes.
     You CANNOT perform Pass-The-Hash attacks with Net-NTLM hashes."

- "You get NTLM hashes when dumping the SAM database of any Windows OS, a Domain Controller's NTDS.dit database or from Mimikatz..." [snipped] "You get Net-NTLMv1/v2 (a.k.a NTLMv1/v2) hashes when using tools like Responder or Inveigh."


